### PR TITLE
Add AWS credentials to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@ Prototype Code for Certara applications
 Contains the following prototype applications
 1. File Uploader Prototype: This is a prototype for loading local files to AWS s3 Storage using AWS SDk for Javascript using Angular front end and intercept HTTP stream to read file upload progress
 2. Data Sharing Prototype: This is a prototype for lazy loading angular components within specific routes and data sharing between routes, modules, components using shared data service, input output decorators, observables.
+
+# AWS Credentials
+### Access Key
+`AKIAIIMAMXA7GUPFSALQ`
+### Secret Key
+`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`


### PR DESCRIPTION
Credentials should be in easy-to-find area so scrapers do not have to dig through history to find them.